### PR TITLE
Add username advice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ cd jira
 # Enter JIRA Username & Password when prompted.
 ```
 
+**To get your username**: log into JIRA in a browser, click your
+profile picture, and select Profile.  Your username is on the left side.
+The API username is *not* the same username you use to log into the web site.
+
 ### Add to the end of your .bashrc or .bash_profile
 
 ```sh


### PR DESCRIPTION
- Add note that API username isn't the same as web
  login username, as this tends to confuse API users.